### PR TITLE
feat: add pre-push hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,5 @@
-npm run lint:affected
+#!/bin/bash
+
+if [ -z "$HUSKY_HOOK" ] || [ "$HUSKY_HOOK" = "pre-commit" ]; then
+    npm run lint:affected
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ "$HUSKY_HOOK" = "pre-push" ]; then
+    npm run lint:affected
+fi


### PR DESCRIPTION
#### Running Linter Only on Pre-Push

To ensure that the linter runs only during the `pre-push` phase, set the `HUSKY_HOOK` environment variable before committing and pushing. Use the following commands:

```bash
HUSKY_HOOK=pre-push git commit
HUSKY_HOOK=pre-push git push
```

#### Running Linter on Every Commit

If you prefer to run the linter with every commit, you can proceed without setting any specific environment variables. Simply use the standard commands:

```bash
git commit
git push
```
