### PR TITLE
feat: new manifest file

### DIFF
--- a/apps/contrast-plugin/public/manifest.json
+++ b/apps/contrast-plugin/public/manifest.json
@@ -1,9 +1,10 @@
 {
-    "name": "Contrast plugin",
-    "code": "http://localhost:4210/plugin.js",
-    "permissions": [
-      "page:read",
-      "file:read",
-      "selection:read"
-    ]
-  }
+  "name": "Contrast plugin",
+  "host": "http://localhost:4210",
+  "code": "/plugin.js",
+  "permissions": [
+    "page:read",
+    "file:read",
+    "selection:read"
+  ]
+}

--- a/apps/contrast-plugin/src/plugin.ts
+++ b/apps/contrast-plugin/src/plugin.ts
@@ -1,4 +1,4 @@
-penpot.ui.open('Contrast plugin', 'http://localhost:4210', {
+penpot.ui.open('Contrast plugin', '', {
   width: 450,
   height: 625,
 });

--- a/apps/icons-plugin/src/assets/manifest.json
+++ b/apps/icons-plugin/src/assets/manifest.json
@@ -1,5 +1,10 @@
 {
   "name": "Icons plugin",
-  "code": "http://localhost:4202/assets/plugin.js",
-  "permissions": ["page:read", "file:read", "selection:read"]
+  "host": "http://localhost:4202",
+  "code": "/assets/plugin.js",
+  "permissions": [
+    "page:read",
+    "file:read",
+    "selection:read"
+  ]
 }

--- a/apps/icons-plugin/src/plugin.ts
+++ b/apps/icons-plugin/src/plugin.ts
@@ -1,4 +1,4 @@
-penpot.ui.open('Icons plugin', 'http://localhost:4202', {
+penpot.ui.open('Icons plugin', '', {
   width: 500,
   height: 600,
 });

--- a/apps/poc-state-plugin/src/assets/manifest.json
+++ b/apps/poc-state-plugin/src/assets/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "POC State Read",
-  "code": "http://localhost:4202/assets/plugin.js",
+  "host": "http://localhost:4202",
+  "code": "/assets/plugin.js",
   "permissions": [
     "page:read",
     "file:read",

--- a/apps/poc-state-plugin/src/plugin.ts
+++ b/apps/poc-state-plugin/src/plugin.ts
@@ -1,6 +1,6 @@
 const GRID = [5, 5];
 
-penpot.ui.open('Plugin name', 'http://localhost:4202', {
+penpot.ui.open('Plugin name', '', {
   width: 500,
   height: 600,
 });

--- a/docs/create-angular-plugin.md
+++ b/docs/create-angular-plugin.md
@@ -102,7 +102,7 @@ This will run two tasks: `serve`, the usual Angular server, and `buildPlugin`, w
 Finally, to load your plugin into Penpot, execute the following command in the browser's console devtools:
 
 ```typescript
-ɵloadPlugin({ manifest: 'http://localhost:4202/manifest.json' });
+ɵloadPluginByUrl('http://localhost:4201/assets/manifest.json');
 ```
 
 ### Learn More About Plugin Development

--- a/docs/create-plugin.md
+++ b/docs/create-plugin.md
@@ -63,7 +63,7 @@ npx nx run example-plugin:build --watch & npx nx run example-plugin:preview
 Finally, to load your plugin into Penpot, execute the following command in the browser's console devtools:
 
 ```typescript
-ɵloadPlugin({ manifest: 'http://localhost:4201/manifest.json' });
+ɵloadPluginByUrl('http://localhost:4201/manifest.json');
 ```
 
 ### Learn More About Plugin Development

--- a/docs/plugin-usage.md
+++ b/docs/plugin-usage.md
@@ -3,7 +3,7 @@
 If you want your plugin to be opened in a modal, then use open UI:
 
 ```ts
-penpot.ui.open('Plugin name', 'http://localhost:4201', {
+penpot.ui.open('Plugin name', '/app.html', {
   width: 500,
   height: 600,
 });

--- a/libs/plugins-runtime/src/index.ts
+++ b/libs/plugins-runtime/src/index.ts
@@ -1,7 +1,11 @@
 import 'ses';
 import './lib/modal/plugin-modal';
 
-import { ɵloadPlugin, setContext } from './lib/load-plugin.js';
+import {
+  ɵloadPlugin,
+  setContext,
+  ɵloadPluginByUrl,
+} from './lib/load-plugin.js';
 import * as api from './lib/api/index.js';
 import type { PenpotContext } from '@penpot/plugin-types';
 
@@ -22,6 +26,7 @@ globalThisAny$.initPluginsRuntime = (context: PenpotContext) => {
 
     globalThisAny$.ɵcontext = context;
     globalThis.ɵloadPlugin = ɵloadPlugin;
+    globalThis.ɵloadPluginByUrl = ɵloadPluginByUrl;
 
     setContext(context);
 

--- a/libs/plugins-runtime/src/lib/api/index.ts
+++ b/libs/plugins-runtime/src/lib/api/index.ts
@@ -18,6 +18,7 @@ import { OpenUIOptions } from '../models/open-ui-options.model.js';
 import openUIApi from './openUI.api.js';
 import { z } from 'zod';
 import type { PluginModalElement } from '../modal/plugin-modal.js';
+import { getValidUrl } from '../parse-manifest.js';
 
 type Callback<T> = (message: T) => void;
 
@@ -71,7 +72,14 @@ export function createApi(context: PenpotContext, manifest: Manifest): Penpot {
     ui: {
       open: (name: string, url: string, options: OpenUIOptions) => {
         const theme = context.getTheme() as 'light' | 'dark';
-        modal = openUIApi(name, url, theme, options);
+
+        modal = openUIApi(
+          name,
+          getValidUrl(manifest.host, url),
+          theme,
+          options
+        );
+
         modal.setTheme(theme);
 
         modal.addEventListener('close', closePlugin, {

--- a/libs/plugins-runtime/src/lib/api/plugin-api.spec.ts
+++ b/libs/plugins-runtime/src/lib/api/plugin-api.spec.ts
@@ -33,6 +33,7 @@ describe('Plugin api', () => {
   const api = createApi(mockContext as any, {
     name: 'test',
     code: '',
+    host: 'http://fake.com',
     permissions: ['page:read', 'file:read', 'selection:read'],
   });
 
@@ -46,7 +47,7 @@ describe('Plugin api', () => {
   describe('ui', () => {
     it('open', () => {
       const name = 'test';
-      const url = 'http://fake.com';
+      const url = 'http://fake.com/';
       const options = { width: 100, height: 100 };
       const openUIApiMock = vi.mocked(openUIApi);
 
@@ -64,7 +65,7 @@ describe('Plugin api', () => {
 
     it('sendMessage', () => {
       const name = 'test';
-      const url = 'http://fake.com';
+      const url = 'http://fake.com/';
       const options = { width: 100, height: 100 };
       const message = { test: 'test' };
       const openUIApiMock = vi.mocked(openUIApi);

--- a/libs/plugins-runtime/src/lib/global.d.ts
+++ b/libs/plugins-runtime/src/lib/global.d.ts
@@ -1,5 +1,8 @@
+import type { Manifest } from './lib/models/manifest.model';
+
 export declare global {
   declare namespace globalThis {
-    function ɵloadPlugin(cofig: PluginConfig): Promise<void>;
+    function ɵloadPlugin(cofig: Manifest): Promise<void>;
+    function ɵloadPluginByUrl(url: string): Promise<void>;
   }
 }

--- a/libs/plugins-runtime/src/lib/load-plugin.ts
+++ b/libs/plugins-runtime/src/lib/load-plugin.ts
@@ -1,8 +1,8 @@
 import type { PenpotContext } from '@penpot/plugin-types';
 
-import { PluginConfig } from './models/plugin-config.model.js';
 import { createApi } from './api/index.js';
-import { parseManifest } from './parse-manifest.js';
+import { loadManifest, loadManifestCode } from './parse-manifest.js';
+import { Manifest } from './models/manifest.model.js';
 
 let isLockedDown = false;
 let lastApi: ReturnType<typeof createApi> | undefined;
@@ -13,10 +13,10 @@ export function setContext(context: PenpotContext) {
   pluginContext = context;
 }
 
-export const ɵloadPlugin = async function (config: PluginConfig) {
-  const { code, manifest } = await parseManifest(config);
-
+export const ɵloadPlugin = async function (manifest: Manifest) {
   try {
+    const code = await loadManifestCode(manifest);
+
     if (!isLockedDown) {
       isLockedDown = true;
       hardenIntrinsics();
@@ -42,4 +42,10 @@ export const ɵloadPlugin = async function (config: PluginConfig) {
   } catch (error) {
     console.error(error);
   }
+};
+
+export const ɵloadPluginByUrl = async function (manifestUrl: string) {
+  const manifest = await loadManifest(manifestUrl);
+
+  ɵloadPlugin(manifest);
 };

--- a/libs/plugins-runtime/src/lib/models/manifest.schema.ts
+++ b/libs/plugins-runtime/src/lib/models/manifest.schema.ts
@@ -2,7 +2,10 @@ import { z } from 'zod';
 
 export const manifestSchema = z.object({
   name: z.string(),
-  code: z.string().url(),
+  host: z.string().url(),
+  code: z.string(),
+  icon: z.string().optional(),
+  description: z.string().max(200).optional(),
   permissions: z.array(
     z.enum([
       'page:read',

--- a/libs/plugins-runtime/src/lib/parse-manifest.ts
+++ b/libs/plugins-runtime/src/lib/parse-manifest.ts
@@ -1,6 +1,9 @@
 import { Manifest } from './models/manifest.model.js';
 import { manifestSchema } from './models/manifest.schema.js';
-import { PluginConfig } from './models/plugin-config.model.js';
+
+export function getValidUrl(host: string, path: string): string {
+  return new URL(path, host).toString();
+}
 
 export function loadManifest(url: string): Promise<Manifest> {
   return fetch(url)
@@ -20,19 +23,12 @@ export function loadManifest(url: string): Promise<Manifest> {
     });
 }
 
-function loadCode(url: string): Promise<string> {
-  return fetch(url).then((response) => response.text());
-}
+export function loadManifestCode(manifest: Manifest): Promise<string> {
+  return fetch(getValidUrl(manifest.host, manifest.code)).then((response) => {
+    if (response.ok) {
+      return response.text();
+    }
 
-export async function parseManifest(config: PluginConfig): Promise<{
-  manifest: Manifest;
-  code: string;
-}> {
-  const manifest = await loadManifest(config.manifest);
-  const code = await loadCode(manifest.code);
-
-  return {
-    manifest,
-    code,
-  };
+    throw new Error('Failed to load plugin code');
+  });
 }


### PR DESCRIPTION
This pull request introduces several enhancements and modifications to the `manifest.json` configuration:

1. **Optional Fields**:
   - Added `description` and `icon` as optional fields.

2. **Host Field**:
   - Introduced the `host` field to the `manifest.json`.

3. **Code Field**:
   - Updated the `code` field to be relative to the `host` field.

4. **URL Handling in `penpot.ui.open`**:
   - Adjusted the URL handling for `penpot.ui.open('Contrast plugin', 'app.html')` so that it is not relative to the `host`.

5. **Loading Manifest by URL**:
   - Implemented the ability to open a manifest using a URL with `ɵloadPluginByUrl('http://localhost:4201/assets/manifest.json')`.

6. **Loading Manifest Object**:
   - Added functionality to load the manifest object directly using `ɵloadPlugin(manifest)`.


