### PR TITLE
style: remove button selector and wrap into data attribute

### DIFF
--- a/apps/poc-state-plugin/src/app/app.component.ts
+++ b/apps/poc-state-plugin/src/app/app.component.ts
@@ -21,7 +21,7 @@ import type { PenpotShape } from '@penpot/plugin-types';
         <div class="name-wrap">
           <label>Selected Shape: </label>
           <input class="input" type="text" formControlName="name" />
-          <button type="submit">Update</button>
+          <button type="submit" data-appearance="primary">Update</button>
         </div>
       </form>
 

--- a/libs/plugins-styles/src/lib/components/button.css
+++ b/libs/plugins-styles/src/lib/components/button.css
@@ -1,4 +1,4 @@
-button {
+:where([data-appearance]:is(button), [role='tab']:is(button)) {
   border: 2px solid transparent;
   font-weight: 500;
   font-size: 12px;


### PR DESCRIPTION
- Remove the `button` tag selector to avoid undesired inheritance in plugins
- Adds a [data] selector for buttons
- Fixes broken style at POC plugin

**Question**: should we keep the current selector as is in this PR, or instead should we duplicate the code of the button in the tab style component?