### PR TITLE
[Proposal] Type renames and naming convention

### DIFF
--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -156,7 +156,7 @@ export interface PluginDataMixin {
    *
    * Returns an array of strings representing all the keys.
    */
-  getPluginDataKeys(): string[]; //QUESTION: isn't there a chance to get null?
+  getPluginDataKeys(): string[];
 
   /**
    * Retrieves the shared plugin-specific data for the given namespace and key.

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -1,5 +1,14 @@
 
 
+/* 
+Naming convention proposal:
+1/ Use {Name + "Node"} for new node entities. e.g. ComponentNode or InstanceNode.
+2/ Use {Name + "Node" + "Mixin"} for node-related properties mixins. E.g. FrameNodeMixin or TextNodeMixin
+3/ Use {Name + "Mixin"} for properties mixins. E.g. GridLayoutMixin or FlexLayoutMixin.
+
+Right now it kinda of mess, especially with properties. See PenpotLayoutChildProperties vs PenpotCommonLayout.
+ */
+
 interface UIAPI {
   /**
    * Opens the plugin UI. It is possible to develop a plugin without interface (see Palette color example) but if you need, the way to open this UI is using `penpot.ui.open`.

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -2709,7 +2709,7 @@ export interface PenpotContext {
    * const svgGroup = context.createShapeFromSvg('<svg>...</svg>');
    * ```
    */
-  createShapeFromSvg(svgString: string): GroupNode | null;
+  createNodeFromSvg(svgString: string): GroupNode | null;
   /**
    * Creates a PenpotText shape with the specified text content. Requires `content:write` permission.
    * @param text The text content for the PenpotText shape.
@@ -2724,8 +2724,6 @@ export interface PenpotContext {
    * text.fontSize = '12';
    * board.appendChild(text);
    * ```
-   * @document
-   * ![example image](https://placehold.co/600x400)
    */
   createText(text: string): TextNode | null;
 

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -187,7 +187,7 @@ export interface PageNode extends PenpotPluginData {
    * Retrieves a shape by its unique identifier.
    * @param id The unique identifier of the shape.
    */
-  getShapeById(id: string): SceneNode | null;
+  getNodeById(id: string): SceneNode | null; // QUESTION: Shouldn't it be on the penpot.getNodeById context? Right now is on PageNode context.
 
 
   // NOTE: this might be more useful if it would be findAll(callback?: (node: PageNode | SceneNode) => boolean): PageNode | SceneNode | null;

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -1,51 +1,54 @@
+
+
+interface UIAPI {
+  /**
+   * Opens the plugin UI. It is possible to develop a plugin without interface (see Palette color example) but if you need, the way to open this UI is using `penpot.ui.open`.
+   * There is a minimum and maximum size for this modal and a default size but it's possible to customize it anyway with the options parameter.
+   *
+   * @param name title of the plugin, it'll be displayed on the top of the modal
+   * @param url of the plugin
+   * @param options height and width of the modal.
+   *
+   * @example
+   * ```js
+   * penpot.ui.open('Plugin name', 'url', {width: 150, height: 300});
+   * ```
+   */
+  open: (name: string, url: string, options?: {
+    width: number;
+    height: number;
+  }) => void;
+  /**
+   * Sends a message to the plugin UI.
+   *
+   * @param message content usually is an object
+   *
+   * @example
+   * ```js
+   * this.sendMessage({ type: 'example-type', content: 'data we want to share' });
+   * ```
+   */
+  sendMessage: (message: unknown) => void;
+  /**
+   * This is usually used in the `plugin.ts` file in order to handle the data sent by our plugin
+   *
+   * @param message content usually is an object
+   *
+   * @example
+   * ```js
+   * penpot.ui.onMessage((message) => {if(message.type === 'example-type' { ...do something })});
+   * ```
+   */
+  onMessage: <T>(callback: (message: T) => void) => void;
+}
+
 /**
  * These are methods and properties available on the `penpot` global object.
  *
  */
 export interface Penpot
   extends Omit<PenpotContext, 'addListener' | 'removeListener'> {
-  ui: {
-    /**
-     * Opens the plugin UI. It is possible to develop a plugin without interface (see Palette color example) but if you need, the way to open this UI is using `penpot.ui.open`.
-     * There is a minimum and maximum size for this modal and a default size but it's possible to customize it anyway with the options parameter.
-     *
-     * @param name title of the plugin, it'll be displayed on the top of the modal
-     * @param url of the plugin
-     * @param options height and width of the modal.
-     *
-     * @example
-     * ```js
-     * penpot.ui.open('Plugin name', 'url', {width: 150, height: 300});
-     * ```
-     */
-    open: (
-      name: string,
-      url: string,
-      options?: { width: number; height: number }
-    ) => void;
-    /**
-     * Sends a message to the plugin UI.
-     *
-     * @param message content usually is an object
-     *
-     * @example
-     * ```js
-     * this.sendMessage({ type: 'example-type', content: 'data we want to share' });
-     * ```
-     */
-    sendMessage: (message: unknown) => void;
-    /**
-     * This is usually used in the `plugin.ts` file in order to handle the data sent by our plugin
-     *
-     * @param message content usually is an object
-     *
-     * @example
-     * ```js
-     * penpot.ui.onMessage((message) => {if(message.type === 'example-type' { ...do something })});
-     * ```
-     */
-    onMessage: <T>(callback: (message: T) => void) => void;
-  };
+  readonly ui: UIAPI;
   /**
    * Provides access to utility functions and context-specific operations.
    */

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -328,7 +328,7 @@ export interface FillsMixin {
  * Represents the cap style of a stroke in Penpot.
  * This type defines various styles for the ends of a stroke.
  */
-export type PenpotStrokeCap =
+export type StrokeCap =
   | 'round'
   | 'square'
   | 'line-arrow'
@@ -341,7 +341,7 @@ export type PenpotStrokeCap =
  * Represents stroke properties in Penpot.
  * This interface includes properties for defining the color, style, width, alignment, and caps of a stroke.
  */
-export interface PenpotStroke {
+export interface StrokesMixin {
   /**
    * The optional color of the stroke, represented as a string (e.g., '#FF5733').
    */
@@ -374,11 +374,11 @@ export interface PenpotStroke {
   /**
    * The optional cap style for the start of the stroke.
    */
-  strokeCapStart?: PenpotStrokeCap;
+  strokeCapStart?: StrokeCap;
   /**
    * The optional cap style for the end of the stroke.
    */
-  strokeCapEnd?: PenpotStrokeCap;
+  strokeCapEnd?: StrokeCap;
   /**
    * The optional gradient stroke defined by a PenpotGradient object.
    */
@@ -389,7 +389,7 @@ export interface PenpotStroke {
  * Represents color properties in Penpot.
  * This interface includes properties for defining solid colors, gradients, and image fills, along with metadata.
  */
-export interface PenpotColor {
+export interface SolidColorMixin {
   /**
    * The optional unique identifier for the color.
    */
@@ -464,7 +464,7 @@ export interface PenpotColorShapeInfo {
  * Represents shadow properties in Penpot.
  * This interface includes properties for defining drop shadows and inner shadows, along with their visual attributes.
  */
-export interface PenpotShadow {
+export interface ShadowMixin {
   /**
    * The optional unique identifier for the shadow.
    */
@@ -499,14 +499,14 @@ export interface PenpotShadow {
   /**
    * The optional color of the shadow, defined by a PenpotColor object.
    */
-  color?: PenpotColor;
+  color?: SolidColorMixin;
 }
 
 /**
  * Represents blur properties in Penpot.
  * This interface includes properties for defining the type and intensity of a blur effect, along with its visibility.
  */
-export interface PenpotBlur {
+export interface BlurMixin {
   /**
    * The optional unique identifier for the blur effect.
    */
@@ -1206,7 +1206,7 @@ export interface SceneNodeMixin extends PenpotPluginData {
   /**
    * Returns the bounding box surrounding the current shape
    */
-  readonly bounds: PenpotBounds;
+  readonly bounds: BoundingBox;
 
   /**
    * Returns the geometric center of the shape
@@ -1292,12 +1292,12 @@ export interface SceneNodeMixin extends PenpotPluginData {
   /**
    * The shadows applied to the shape.
    */
-  shadows: PenpotShadow[];
+  shadows: ShadowMixin[];
 
   /**
    * The blur effect applied to the shape.
    */
-  blur?: PenpotBlur;
+  blur?: BlurMixin;
 
   /**
    * The export settings of the shape.
@@ -1347,7 +1347,7 @@ export interface SceneNodeMixin extends PenpotPluginData {
   /**
    * The strokes applied to the shape.
    */
-  strokes: PenpotStroke[];
+  strokes: StrokesMixin[];
 
   /**
    * Layout properties for children of the shape.
@@ -1885,6 +1885,7 @@ export interface ImageNode extends SceneNodeMixin {
   fills: FillsMixin[];
 }
 
+// Isn't this the position? This might be reusable everywhere.
 /**
  * PenpotPoint represents a point in 2D space, typically with x and y coordinates.
  */
@@ -1894,7 +1895,7 @@ export type PenpotPoint = { x: number; y: number };
  * PenpotBounds represents the boundaries of a rectangular area,
  * defined by the coordinates of the top-left corner and the dimensions of the rectangle.
  */
-export type PenpotBounds = {
+export type BoundingBox = {
   /**
    * Top-left x position of the rectangular area defined
    */
@@ -1917,10 +1918,10 @@ export type PenpotBounds = {
  * PenpotViewport represents the viewport in the Penpot application.
  * It includes the center point, zoom level, and the bounds of the viewport.
  */
-export interface PenpotViewport {
+export interface Viewport {
   center: PenpotPoint;
   zoom: number;
-  readonly bounds: PenpotBounds;
+  readonly bounds: BoundingBox;
 }
 
 /**
@@ -2041,7 +2042,7 @@ export interface PenpotLibraryColor extends PenpotLibraryElement {
    * const stroke = libraryColor.asStroke();
    * ```
    */
-  asStroke(): PenpotStroke;
+  asStroke(): StrokesMixin;
 }
 
 /**
@@ -2125,7 +2126,7 @@ export interface PenpotLibraryTypography extends PenpotLibraryElement {
    * typographyElement.setFont(newFont, newVariant);
    * ```
    */
-  setFont(font: PenpotFont, variant?: PenpotFontVariant): void;
+  setFont(font: FontMixin, variant?: FontVariantMixin): void;
 }
 
 /**
@@ -2293,7 +2294,7 @@ export type PenpotLibraryContext = {
  * Represents a font variant in Penpot, which defines a specific style variation of a font.
  * This interface provides properties for describing the characteristics of a font variant.
  */
-export interface PenpotFontVariant {
+export interface FontVariantMixin {
   /**
    * The name of the font variant.
    */
@@ -2319,7 +2320,7 @@ export interface PenpotFontVariant {
  * Represents a font in Penpot, which includes details about the font family, variants, and styling options.
  * This interface provides properties and methods for describing and applying fonts within Penpot.
  */
-export interface PenpotFont {
+export interface FontMixin {
   /**
    * This property holds the human-readable name of the font.
    */
@@ -2353,21 +2354,21 @@ export interface PenpotFont {
   /**
    * An array of font variants available for the font.
    */
-  variants: PenpotFontVariant[];
+  variants: FontVariantMixin[];
 
   /**
    * Applies the font styles to a text shape.
    * @param text - The text shape to apply the font styles to.
    * @param variant - Optional. The specific font variant to apply. If not provided, applies the default variant.
    */
-  applyToText(text: TextNode, variant?: PenpotFontVariant): void;
+  applyToText(text: TextNode, variant?: FontVariantMixin): void;
 
   /**
    * Applies the font styles to a text range within a text shape.
    * @param range - The text range to apply the font styles to.
    * @param variant - Optional. The specific font variant to apply. If not provided, applies the default variant.
    */
-  applyToRange(range: PenpotTextRange, variant?: PenpotFontVariant): void;
+  applyToRange(range: PenpotTextRange, variant?: FontVariantMixin): void;
 }
 
 /**
@@ -2378,35 +2379,35 @@ export interface PenpotFontsContext {
   /**
    * An array containing all available fonts.
    */
-  all: PenpotFont[];
+  all: FontMixin[];
 
   /**
    * Finds a font by its unique identifier.
    * Returns the `PenpotFont` object if found, otherwise `null`.
    * @param id - The ID of the font to find.
    */
-  findById(id: string): PenpotFont | null;
+  findById(id: string): FontMixin | null;
 
   /**
    * Finds a font by its name.
    * Returns the `PenpotFont` object if found, otherwise `null`.
    * @param name - The name of the font to find.
    */
-  findByName(name: string): PenpotFont | null;
+  findByName(name: string): FontMixin | null;
 
   /**
    * Finds all fonts matching a specific ID.
    * Returns an array of `PenpotFont` objects matching the provided ID.
    * @param id - The ID to match against.
    */
-  findAllById(id: string): PenpotFont[];
+  findAllById(id: string): FontMixin[];
 
   /**
    * Finds all fonts matching a specific name.
    * Returns an array of `PenpotFont` objects matching the provided name.
    * @param name - The name to match against.
    */
-  findAllByName(name: string): PenpotFont[];
+  findAllByName(name: string): FontMixin[];
 }
 
 /**
@@ -2510,7 +2511,7 @@ export interface PenpotContext {
    * const viewportSettings = context.viewport;
    * ```
    */
-  readonly viewport: PenpotViewport;
+  readonly viewport: Viewport;
   /**
    * The library context in the Penpot context, including both local and connected libraries. Requires `library:read` permission.
    * @example
@@ -2590,15 +2591,15 @@ export interface PenpotContext {
    * Retrieves colors applied to the given shapes in Penpot. Requires `content:read` permission.
    * Returns an array of colors and their shape information.
    */
-  shapesColors(shapes: SceneNode[]): (PenpotColor & PenpotColorShapeInfo)[];
+  shapesColors(shapes: SceneNode[]): (SolidColorMixin & PenpotColorShapeInfo)[];
 
   /**
    * Replaces a specified old color with a new color in the given shapes. Requires `content:write` permission.
    */
   replaceColor(
     shapes: SceneNode[],
-    oldColor: PenpotColor,
-    newColor: PenpotColor
+    oldColor: SolidColorMixin,
+    newColor: SolidColorMixin
   ): void;
 
   /**

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -161,20 +161,20 @@ export interface PenpotPluginData {
 }
 
 /**
- * PenpotFile represents a file in the Penpot application.
+ * FileNode represents a file in the Penpot application.
  * It includes properties for the file's identifier, name, and revision number.
  */
-export interface PenpotFile extends PenpotPluginData {
+export interface FileNode extends PenpotPluginData {
   id: string;
   name: string;
   revn: number;
 }
 
 /**
- * PenpotPage represents a page in the Penpot application.
+ * PageNode represents a page in the Penpot application.
  * It includes properties for the page's identifier and name, as well as methods for managing shapes on the page.
  */
-export interface PenpotPage extends PenpotPluginData {
+export interface PageNode extends PenpotPluginData {
   /**
    * The `id` property is a unique identifier for the page.
    */
@@ -187,8 +187,10 @@ export interface PenpotPage extends PenpotPluginData {
    * Retrieves a shape by its unique identifier.
    * @param id The unique identifier of the shape.
    */
-  getShapeById(id: string): PenpotShape | null;
+  getShapeById(id: string): SceneNode | null;
 
+
+  // NOTE: this might be more useful if it would be findAll(callback?: (node: PageNode | SceneNode) => boolean): PageNode | SceneNode | null;
   /**
    * Finds all shapes on the page.
    * Optionaly it gets a criteria object to search for specific criteria
@@ -209,7 +211,7 @@ export interface PenpotPage extends PenpotPluginData {
       | 'circle'
       | 'svg-raw'
       | 'image';
-  }): PenpotShape[];
+  }): SceneNode[];
 }
 
 /**
@@ -877,7 +879,7 @@ export interface PenpotGridLayout extends PenpotCommonLayout {
    * @param row The row index where the child will be placed.
    * @param column The column index where the child will be placed.
    */
-  appendChild(child: PenpotShape, row: number, column: number): void;
+  appendChild(child: SceneNode, row: number, column: number): void;
 }
 
 /**
@@ -904,7 +906,7 @@ export interface PenpotFlexLayout extends PenpotCommonLayout {
    * Appends a child element to the flex layout.
    * @param child The child element to be appended, of type `PenpotShape`.
    */
-  appendChild(child: PenpotShape): void;
+  appendChild(child: SceneNode): void;
 }
 
 /**
@@ -1157,6 +1159,8 @@ export interface PenpotLayoutCellProperties {
  * This interface provides common properties and methods shared by all shapes.
  */
 export interface PenpotShapeBase extends PenpotPluginData {
+  // NOTE: it will help on long run to split in smaller chunks.
+  // TODO: rename to SceneNodeMixin (double-check)
   /**
    * The unique identifier of the shape.
    */
@@ -1377,19 +1381,19 @@ export interface PenpotShapeBase extends PenpotPluginData {
    * Returns the equivalent shape in the component main instance. If the current shape is inside a
    * main instance will return `null`;
    */
-  componentRefShape(): PenpotShape | null;
+  componentRefShape(): SceneNode | null;
 
   /*
    * Returns the root of the component tree structure for the current shape. If the current shape
    * is already a root will return itself.
    */
-  componentRoot(): PenpotShape | null;
+  componentRoot(): SceneNode | null;
 
   /*
    * Returns the head of the component tree structure for the current shape. If the current shape
    * is already a head will return itself.
    */
-  componentHead(): PenpotShape | null;
+  componentHead(): SceneNode | null;
 
   /*
    * If the shape is a component instance, returns the reference to the component associated
@@ -1420,7 +1424,7 @@ export interface PenpotShapeBase extends PenpotPluginData {
    * Creates a clone of the shape.
    * Returns a new instance of the shape with identical properties.
    */
-  clone(): PenpotShape;
+  clone(): SceneNode;
   /**
    * Removes the shape from its parent.
    */
@@ -1431,7 +1435,7 @@ export interface PenpotShapeBase extends PenpotPluginData {
  * Represents a frame in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties and methods specific to frames.
  */
-export interface PenpotFrame extends PenpotShapeBase {
+export interface FrameNode extends PenpotShapeBase {
   /**
    * The type of the shape, which is always 'frame' for frames.
    */
@@ -1469,18 +1473,18 @@ export interface PenpotFrame extends PenpotShapeBase {
   /**
    * The children shapes contained within the frame.
    */
-  readonly children: PenpotShape[];
+  readonly children: SceneNode[];
   /**
    * Appends a child shape to the frame.
    * @param child The child shape to append.
    */
-  appendChild(child: PenpotShape): void;
+  appendChild(child: SceneNode): void;
   /**
    * Inserts a child shape at the specified index within the frame.
    * @param index The index at which to insert the child shape.
    * @param child The child shape to insert.
    */
-  insertChild(index: number, child: PenpotShape): void;
+  insertChild(index: number, child: SceneNode): void;
 
   // Grid layout
   /**
@@ -1499,7 +1503,7 @@ export interface PenpotFrame extends PenpotShapeBase {
  * Represents a group of shapes in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties and methods specific to groups.
  */
-export interface PenpotGroup extends PenpotShapeBase {
+export interface GroupNode extends PenpotShapeBase {
   /**
    * The type of the shape, which is always 'group' for groups.
    */
@@ -1509,18 +1513,18 @@ export interface PenpotGroup extends PenpotShapeBase {
   /**
    * The children shapes contained within the group.
    */
-  readonly children: PenpotShape[];
+  readonly children: SceneNode[];
   /**
    * Appends a child shape to the group.
    * @param child The child shape to append.
    */
-  appendChild(child: PenpotShape): void;
+  appendChild(child: SceneNode): void;
   /**
    * Inserts a child shape at the specified index within the group.
    * @param index The index at which to insert the child shape.
    * @param child The child shape to insert.
    */
-  insertChild(index: number, child: PenpotShape): void;
+  insertChild(index: number, child: SceneNode): void;
 
   /**
    * Checks if the group is currently a mask.
@@ -1552,7 +1556,7 @@ export type PenpotBoolType =
  * Represents a boolean operation shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties and methods specific to boolean operations.
  */
-export interface PenpotBool extends PenpotShapeBase {
+export interface BooleanNode extends PenpotShapeBase {
   /**
    * The type of the shape, which is always 'bool' for boolean operation shapes.
    */
@@ -1577,25 +1581,25 @@ export interface PenpotBool extends PenpotShapeBase {
   /**
    * The children shapes contained within the boolean shape.
    */
-  readonly children: PenpotShape[];
+  readonly children: SceneNode[];
   /**
    * Appends a child shape to the boolean shape.
    * @param child The child shape to append.
    */
-  appendChild(child: PenpotShape): void;
+  appendChild(child: SceneNode): void;
   /**
    * Inserts a child shape at the specified index within the boolean shape.
    * @param index The index at which to insert the child shape.
    * @param child The child shape to insert.
    */
-  insertChild(index: number, child: PenpotShape): void;
+  insertChild(index: number, child: SceneNode): void;
 }
 
 /**
  * Represents a rectangle shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties specific to rectangles.
  */
-export interface PenpotRectangle extends PenpotShapeBase {
+export interface RectangleNode extends PenpotShapeBase {
   /**
    * The type of the shape, which is always 'rect' for rectangle shapes.
    */
@@ -1611,7 +1615,7 @@ export interface PenpotRectangle extends PenpotShapeBase {
  * Represents a path shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties and methods specific to paths.
  */
-export interface PenpotPath extends PenpotShapeBase {
+export interface VectorNode extends PenpotShapeBase {
   /**
    * The type of the shape, which is always 'path' for path shapes.
    */
@@ -1640,7 +1644,7 @@ export interface PenpotTextRange {
   /**
    * The PenpotText shape to which this text range belongs.
    */
-  readonly shape: PenpotText;
+  readonly shape: TextNode;
 
   /**
    * The characters associated with the current text range.
@@ -1735,7 +1739,7 @@ export interface PenpotTextRange {
  * PenpotText represents a text element in the Penpot application, extending the base shape interface.
  * It includes various properties to define the text content and its styling attributes.
  */
-export interface PenpotText extends PenpotShapeBase {
+export interface TextNode extends PenpotShapeBase {
   /**
    * The type of the shape, which is always 'text' for text shapes.
    */
@@ -1839,7 +1843,7 @@ export interface PenpotText extends PenpotShapeBase {
  * Represents an ellipse shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties specific to ellipses.
  */
-export interface PenpotEllipse extends PenpotShapeBase {
+export interface EllipseNode extends PenpotShapeBase {
   type: 'circle';
 
   /**
@@ -1852,7 +1856,7 @@ export interface PenpotEllipse extends PenpotShapeBase {
  * Represents an SVG raw shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties specific to raw SVG shapes.
  */
-export interface PenpotSvgRaw extends PenpotShapeBase {
+export interface SvgRawNode extends PenpotShapeBase {
   type: 'svg-raw';
 }
 
@@ -1860,7 +1864,7 @@ export interface PenpotSvgRaw extends PenpotShapeBase {
  * Represents an image shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties specific to image shapes.
  */
-export interface PenpotImage extends PenpotShapeBase {
+export interface ImageNode extends PenpotShapeBase {
   type: 'image';
 
   /**
@@ -1908,19 +1912,19 @@ export interface PenpotViewport {
 }
 
 /**
- * PenpotShape represents a union of various shape types used in the Penpot project.
- * This type allows for different shapes to be handled under a single type umbrella.
+ * SceneNode represents all the nodes that can exists within a PageNode.
  */
-export type PenpotShape =
-  | PenpotFrame
-  | PenpotGroup
-  | PenpotBool
-  | PenpotRectangle
-  | PenpotPath
-  | PenpotText
-  | PenpotEllipse
-  | PenpotSvgRaw
-  | PenpotImage;
+
+export type SceneNode =
+  | FrameNode
+  | GroupNode
+  | BooleanNode
+  | RectangleNode
+  | VectorNode
+  | TextNode
+  | EllipseNode
+  | SvgRawNode
+  | ImageNode;
 
 /**
  * Represents a mapping of events to their corresponding types in Penpot.
@@ -1930,11 +1934,11 @@ export interface EventsMap {
   /**
    * The `pagechange` event is triggered when the active page in the project is changed.
    */
-  pagechange: PenpotPage;
+  pagechange: PageNode;
   /**
    * The `filechange` event is triggered when there are changes in the current file.
    */
-  filechange: PenpotFile;
+  filechange: FileNode;
   /**
    * The `selectionchange` event is triggered when the selection of elements changes.
    * This event passes a list of identifiers of the selected elements.
@@ -2031,6 +2035,7 @@ export interface PenpotLibraryColor extends PenpotLibraryElement {
  * This interface extends `PenpotLibraryElement` and includes properties specific to typography elements.
  */
 export interface PenpotLibraryTypography extends PenpotLibraryElement {
+  // Question: i don't understand why are these method not specific to TextNode?
   /**
    * The unique identifier of the font used in the typography element.
    */
@@ -2078,14 +2083,15 @@ export interface PenpotLibraryTypography extends PenpotLibraryElement {
 
   /**
    * Applies the typography styles to a text shape.
-   * @param shape The text shape to apply the typography styles to.
+   * @param node The node to apply the typography styles to.
    * @example
    * ```js
    * typographyElement.applyToText(textShape);
    * ```
    */
-  applyToText(shape: PenpotShape): void;
+  applyToText(node: SceneNode): void;
 
+  // NOTE: something is wrong here, the shape doesn't exist.
   /**
    * Applies the typography styles to a range of text within a text shape.
    * @param shape The text shape containing the text range to apply the typography styles to.
@@ -2121,12 +2127,12 @@ export interface PenpotLibraryComponent extends PenpotLibraryElement {
    * const componentInstance = libraryComponent.instance();
    * ```
    */
-  instance(): PenpotShape;
+  instance(): SceneNode;
 
   /*
    * Returns the reference to the main component shape.
    */
-  mainInstance(): PenpotShape;
+  mainInstance(): SceneNode;
 }
 
 /**
@@ -2211,14 +2217,14 @@ export interface PenpotLibrary extends PenpotPluginData {
 
   /**
    * Creates a new component element in the library using the provided shapes.
-   * @param shapes An array of `PenpotShape` objects representing the shapes to be included in the component.
+   * @param nodes An array of all nodes to be included in the component.
    * Returns a new `PenpotLibraryComponent` object representing the created component element.
    * @example
    * ```js
    * const newComponent = library.createComponent([shape1, shape2]);
    * ```
    */
-  createComponent(shapes: PenpotShape[]): PenpotLibraryComponent;
+  createComponent(nodes: SceneNode[]): PenpotLibraryComponent;
 }
 
 /**
@@ -2340,7 +2346,7 @@ export interface PenpotFont {
    * @param text - The text shape to apply the font styles to.
    * @param variant - Optional. The specific font variant to apply. If not provided, applies the default variant.
    */
-  applyToText(text: PenpotText, variant?: PenpotFontVariant): void;
+  applyToText(text: TextNode, variant?: PenpotFontVariant): void;
 
   /**
    * Applies the font styles to a text range within a text shape.
@@ -2466,6 +2472,7 @@ export interface PenpotActiveUser extends PenpotUser {
  * Represents the context of Penpot, providing access to various Penpot functionalities and data.
  */
 export interface PenpotContext {
+  
   /**
    * The root shape in the current Penpot context. Requires `content:read` permission.
    * @example
@@ -2473,7 +2480,7 @@ export interface PenpotContext {
    * const rootShape = context.root;
    * ```
    */
-  readonly root: PenpotShape;
+  readonly root: SceneNode; // I suppose root should always be FileNode
   /**
    * The current page in the Penpot context. Requires `content:read` permission.
    * @example
@@ -2481,7 +2488,7 @@ export interface PenpotContext {
    * const currentPage = context.currentPage;
    * ```
    */
-  readonly currentPage: PenpotPage;
+  readonly currentPage: PageNode;
   /**
    * The viewport settings in the Penpot context.
    * @example
@@ -2526,7 +2533,7 @@ export interface PenpotContext {
    * const selectedShapes = context.selection;
    * ```
    */
-  selection: PenpotShape[];
+  selection: SceneNode[];
 
   /**
    * Retrieves file data from the current Penpot context. Requires `content:read` permission.
@@ -2536,7 +2543,7 @@ export interface PenpotContext {
    * const fileData = context.getFile();
    * ```
    */
-  getFile(): PenpotFile | null;
+  getFile(): FileNode | null;
   /**
    * Retrieves page data from the current Penpot context. Requires `content:read` permission.
    * Returns the page data or `null` if no page is available.
@@ -2545,7 +2552,7 @@ export interface PenpotContext {
    * const pageData = context.getPage();
    * ```
    */
-  getPage(): PenpotPage | null;
+  getPage(): PageNode | null;
   /**
    * Retrieves the IDs of the currently selected elements in Penpot. Requires `content:read` permission.
    * Returns an array of IDs representing the selected elements.
@@ -2563,19 +2570,19 @@ export interface PenpotContext {
    * const selectedShapes = context.getSelectedShapes();
    * ```
    */
-  getSelectedShapes(): PenpotShape[];
+  getSelectedShapes(): SceneNode[];
 
   /**
    * Retrieves colors applied to the given shapes in Penpot. Requires `content:read` permission.
    * Returns an array of colors and their shape information.
    */
-  shapesColors(shapes: PenpotShape[]): (PenpotColor & PenpotColorShapeInfo)[];
+  shapesColors(shapes: SceneNode[]): (PenpotColor & PenpotColorShapeInfo)[];
 
   /**
    * Replaces a specified old color with a new color in the given shapes. Requires `content:write` permission.
    */
   replaceColor(
-    shapes: PenpotShape[],
+    shapes: SceneNode[],
     oldColor: PenpotColor,
     newColor: PenpotColor
   ): void;
@@ -2616,16 +2623,16 @@ export interface PenpotContext {
 
   /**
    * Groups the specified shapes. Requires `content:write` permission.
-   * @param shapes - An array of shapes to group.
+   * @param nodes - An array of nodes to group.
    * Returns the newly created group or `null` if the group could not be created.
    */
-  group(shapes: PenpotShape[]): PenpotGroup | null;
+  group(nodes: SceneNode[]): GroupNode | null;
   /**
    * Ungroups the specified group. Requires `content:write` permission.
    * @param group - The group to ungroup.
    * @param other - Additional groups to ungroup.
    */
-  ungroup(group: PenpotGroup, ...other: PenpotGroup[]): void;
+  ungroup(group: GroupNode, ...other: GroupNode[]): void;
 
   /**
    * Use this method to create the shape of a rectangle. Requires `content:write` permission.
@@ -2635,7 +2642,7 @@ export interface PenpotContext {
    * penpot.createRectangle();
    * ```
    */
-  createRectangle(): PenpotRectangle;
+  createRectangle(): RectangleNode;
   /**
    * Use this method to create a frame. This is the first step before anything else, the container. Requires `content:write` permission.
    * Then you can add a gridlayout, flexlayout or add a shape inside the frame.
@@ -2645,7 +2652,7 @@ export interface PenpotContext {
    * penpot.createFrame();
    * ```
    */
-  createFrame(): PenpotFrame;
+  createFrame(): FrameNode;
   /**
    * Use this method to create the shape of a ellipse. Requires `content:write` permission.
    *
@@ -2654,7 +2661,7 @@ export interface PenpotContext {
    * penpot.createEllipse();
    * ```
    */
-  createEllipse(): PenpotEllipse;
+  createEllipse(): EllipseNode;
   /**
    * Use this method to create a path. Requires `content:write` permission.
    *
@@ -2663,11 +2670,11 @@ export interface PenpotContext {
    * penpot.createPath();
    * ```
    */
-  createPath(): PenpotPath;
+  createPath(): VectorNode;
   /**
    * Creates a PenpotBoolean shape based on the specified boolean operation and shapes. Requires `content:write` permission.
    * @param boolType The type of boolean operation ('union', 'difference', 'exclude', 'intersection').
-   * @param shapes An array of shapes to perform the boolean operation on.
+   * @param nodes An array of nodes to perform the boolean operation on.
    * Returns the newly created PenpotBoolean shape resulting from the boolean operation.
    * @example
    * ```js
@@ -2676,8 +2683,8 @@ export interface PenpotContext {
    */
   createBoolean(
     boolType: PenpotBoolType,
-    shapes: PenpotShape[]
-  ): PenpotBool | null;
+    nodes: SceneNode[]
+  ): BooleanNode | null;
   /**
    * Creates a PenpotGroup from an SVG string. Requires `content:write` permission.
    * @param svgString The SVG string representing the shapes to be converted into a group.
@@ -2687,7 +2694,7 @@ export interface PenpotContext {
    * const svgGroup = context.createShapeFromSvg('<svg>...</svg>');
    * ```
    */
-  createShapeFromSvg(svgString: string): PenpotGroup | null;
+  createShapeFromSvg(svgString: string): GroupNode | null;
   /**
    * Creates a PenpotText shape with the specified text content. Requires `content:write` permission.
    * @param text The text content for the PenpotText shape.
@@ -2705,27 +2712,27 @@ export interface PenpotContext {
    * @document
    * ![example image](https://placehold.co/600x400)
    */
-  createText(text: string): PenpotText | null;
+  createText(text: string): TextNode | null;
 
   /**
-   * Generates markup for the given shapes. Requires `content:read` permission
-   * @param shapes
+   * Generates markup for the given nodes. Requires `content:read` permission
+   * @param nodes
    * @param markupType will default to 'html'
    */
   generateMarkup(
-    shapes: PenpotShape[],
+    nodes: SceneNode[],
     options?: { type?: 'html' | 'svg' }
   ): string;
 
   /**
-   * Generates styles for the given shapes. Requires `content:read` permission
-   * @param shapes
+   * Generates styles for the given nodes. Requires `content:read` permission
+   * @param nodes
    * @param styleType will default to 'css'
    * @param withPrelude will default to `false`
    * @param includeChildren will default to `true`
    */
   generateStyle(
-    shapes: PenpotShape[],
+    nodes: SceneNode[],
     options?: {
       type?: 'css';
       withPrelude?: boolean;
@@ -2753,81 +2760,81 @@ export interface PenpotContext {
  */
 export interface PenpotContextGeometryUtils {
   /**
-   * Calculates the center point of a given array of shapes.
+   * Calculates the center point of a given array of nodes.
    * This method computes the geometric center (centroid) of the bounding boxes of the provided shapes.
    * Returns the center point as an object with `x` and `y` coordinates, or null if the array is empty.
-   * @param shapes - The array of shapes to calculate the center for.
+   * @param nodes - The array of nodes to calculate the center for.
    *
    */
-  center(shapes: PenpotShape[]): { x: number; y: number } | null;
+  center(nodes: SceneNode[]): { x: number; y: number } | null;
 }
 
 /**
- * Utility methods for determining the types of Penpot shapes.
+ * Utility methods for determining the types of Penpot nodes.
  */
 export interface PenpotContextTypesUtils {
   /**
    * Checks if the given shape is a frame.
    * Returns true if the shape is a PenpotFrame, otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isFrame(shape: PenpotShape): shape is PenpotFrame;
+  isFrame(node: SceneNode): node is FrameNode;
 
   /**
    * Checks if the given shape is a group.
    * Returns true if the shape is a PenpotGroup, otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isGroup(shape: PenpotShape): shape is PenpotGroup;
+  isGroup(node: SceneNode): node is GroupNode;
 
   /**
    * Checks if the given shape is a mask.
    * Returns true if the shape is a PenpotGroup (acting as a mask), otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isMask(shape: PenpotShape): shape is PenpotGroup;
+  isMask(node: SceneNode): node is GroupNode;
 
   /**
    * Checks if the given shape is a boolean operation.
    * Returns true if the shape is a PenpotBool, otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isBool(shape: PenpotShape): shape is PenpotBool;
+  isBool(node: SceneNode): node is BooleanNode;
 
   /**
    * Checks if the given shape is a rectangle.
    * Returns true if the shape is a PenpotRectangle, otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isRectangle(shape: PenpotShape): shape is PenpotRectangle;
+  isRectangle(node: SceneNode): node is RectangleNode;
 
   /**
    * Checks if the given shape is a path.
    * Returns true if the shape is a PenpotPath, otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isPath(shape: PenpotShape): shape is PenpotPath;
+  isPath(node: SceneNode): node is VectorNode;
 
   /**
    * Checks if the given shape is a text element.
    * Returns true if the shape is a PenpotText, otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isText(shape: PenpotShape): shape is PenpotText;
+  isText(node: SceneNode): node is TextNode;
 
   /**
    * Checks if the given shape is an ellipse.
    * Returns true if the shape is a PenpotEllipse, otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isEllipse(shape: PenpotShape): shape is PenpotEllipse;
+  isEllipse(node: SceneNode): node is EllipseNode;
 
   /**
    * Checks if the given shape is an SVG.
    * Returns true if the shape is a PenpotSvgRaw, otherwise false.
-   * @param shape - The shape to check.
+   * @param node - The shape to check.
    */
-  isSVG(shape: PenpotShape): shape is PenpotSvgRaw;
+  isSVG(node: SceneNode): node is SvgRawNode;
 }
 
 /**

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -223,7 +223,7 @@ export interface FileNode extends PluginDataMixin {
   /**
    * List all the pages for the current file
    */
-  pages: PageNode[];
+  pages: PageNode[]; // NOTE: This should be 'children'. And be consistent with everything else. Parent > Child hierarchy.
 }
 
 /**

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -201,21 +201,13 @@ export interface PageNode extends PenpotPluginData {
    * @param `criteria.nameLike` search for name but for a partial match with the name
    * @param `criteria.type` search for shapes of the specified type
    */
-  findShapes(criteria?: {
+  findNodesBy(criteria?: {
     name?: string;
     nameLike?: string;
-    type?:
-      | 'frame'
-      | 'group'
-      | 'bool'
-      | 'rect'
-      | 'path'
-      | 'text'
-      | 'circle'
-      | 'svg-raw'
-      | 'image';
-  }): SceneNode[];
+    type?: SceneNodeTypes;
+  }): SceneNode[] | null;
 }
+
 
 /**
  * Represents a gradient configuration in Penpot.
@@ -1928,6 +1920,8 @@ export type SceneNode =
   | EllipseNode
   | SvgRawNode
   | ImageNode;
+
+  export type SceneNodeTypes = SceneNode['type']
 
 /**
  * Represents a mapping of events to their corresponding types in Penpot.

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -534,12 +534,11 @@ export interface BlurMixin {
   hidden?: boolean;
 }
 
-// TODO: refactor this
 /**
  * Represents parameters for frame guide columns in Penpot.
  * This interface includes properties for defining the appearance and layout of column guides within a frame.
  */
-export interface PenpotFrameGuideColumnParams {
+export interface RowsColsGuideParams {
   /**
    * The color configuration for the column guides.
    */
@@ -574,7 +573,7 @@ export interface PenpotFrameGuideColumnParams {
  * Represents parameters for frame guide squares in Penpot.
  * This interface includes properties for defining the appearance and size of square guides within a frame.
  */
-export interface PenpotFrameGuideSquareParams {
+export interface SquaresGuideParams {
   /**
    * The color configuration for the square guides.
    */
@@ -589,7 +588,7 @@ export interface PenpotFrameGuideSquareParams {
  * Represents a frame guide for columns in Penpot.
  * This interface includes properties for defining the type, visibility, and parameters of column guides within a frame.
  */
-export interface PenpotFrameGuideColumn {
+export interface ColsGuide {
   /**
    * The type of the guide, which is always 'column' for column guides.
    */
@@ -601,14 +600,14 @@ export interface PenpotFrameGuideColumn {
   /**
    * The parameters defining the appearance and layout of the column guides.
    */
-  params: PenpotFrameGuideColumnParams;
+  params: RowsColsGuideParams;
 }
 
 /**
  * Represents a frame guide for rows in Penpot.
  * This interface includes properties for defining the type, visibility, and parameters of row guides within a frame.
  */
-export interface PenpotFrameGuideRow {
+export interface RowsGuide {
   /**
    * The type of the guide, which is always 'row' for row guides.
    */
@@ -621,14 +620,14 @@ export interface PenpotFrameGuideRow {
    * The parameters defining the appearance and layout of the row guides.
    * Note: This reuses the same parameter structure as column guides.
    */
-  params: PenpotFrameGuideColumnParams;
+  params: RowsColsGuideParams;
 }
 
 /**
  * Represents a frame guide for squares in Penpot.
  * This interface includes properties for defining the type, visibility, and parameters of square guides within a frame.
  */
-export interface PenpotFrameGuideSquare {
+export interface SquaresGuide {
   /**
    * The type of the guide, which is always 'square' for square guides.
    */
@@ -640,17 +639,14 @@ export interface PenpotFrameGuideSquare {
   /**
    * The parameters defining the appearance and layout of the square guides.
    */
-  params: PenpotFrameGuideSquareParams;
+  params: SquaresGuideParams;
 }
 
 /**
  * Represents a frame guide in Penpot.
  * This type can be one of several specific frame guide types: column, row, or square.
  */
-export type PenpotFrameGuide =
-  | PenpotFrameGuideColumn
-  | PenpotFrameGuideRow
-  | PenpotFrameGuideSquare;
+export type Guide = ColsGuide | RowsGuide | SquaresGuide;
 
 /**
  * Represents export settings in Penpot.
@@ -1473,7 +1469,7 @@ export interface FrameNode extends SceneNodeMixin {
   /**
    * The guides associated with the frame.
    */
-  guides: PenpotFrameGuide;
+  guides: Guide[] | null;
 
   /**
    * The horizontal sizing behavior of the frame.

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -12,10 +12,18 @@ The context is also important: we're already inside penpot file, so there is no 
 Repeating Penpot makes everything longer without adding any value to it.
  */
 
+/**
+ *  @defaults { width: 300, height: 200 }
+ *  @minimum { width: 80, height: 100 }
+ */
+interface UIOptions {
+  width: number;
+  height: number;
+}
+
 interface UIAPI {
   /**
    * Opens the plugin UI. It is possible to develop a plugin without interface (see Palette color example) but if you need, the way to open this UI is using `penpot.ui.open`.
-   * There is a minimum and maximum size for this modal and a default size but it's possible to customize it anyway with the options parameter.
    *
    * @param name title of the plugin, it'll be displayed on the top of the modal
    * @param url of the plugin
@@ -26,14 +34,7 @@ interface UIAPI {
    * penpot.ui.open('Plugin name', 'url', {width: 150, height: 300});
    * ```
    */
-  open: (
-    name: string,
-    url: string,
-    options?: {
-      width: number;
-      height: number;
-    }
-  ) => void;
+  open: (name: string, url: string, options?: UIOptions) => void;
 
   /**
    * Sends a message from the code to the plugin UI.

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -5,8 +5,12 @@ Naming convention proposal:
 1/ Use {Name + "Node"} for new node entities. e.g. ComponentNode or InstanceNode.
 2/ Use {Name + "Node" + "Mixin"} for node-related properties mixins. E.g. FrameNodeMixin or TextNodeMixin
 3/ Use {Name + "Mixin"} for properties mixins. E.g. GridLayoutMixin or FlexLayoutMixin.
+4/ Additional, if there is a minimum required mixin, then it can be called {"Minimal" + MixinName}
 
 Right now it kinda of mess, especially with properties. See PenpotLayoutChildProperties vs PenpotCommonLayout.
+
+The context is also important: we're already inside penpot file, so there is no need to repeat Penpot everywhere.
+Repeating Penpot makes everything longer without adding any value to it.
  */
 
 interface UIAPI {
@@ -222,7 +226,7 @@ export interface PageNode extends PenpotPluginData {
  * Represents a gradient configuration in Penpot.
  * A gradient can be either linear or radial and includes properties to define its shape, position, and color stops.
  */
-export type PenpotGradient = {
+export type GradientMixin = {
   /**
    * Specifies the type of gradient.
    * - 'linear': A gradient that transitions colors along a straight line.
@@ -259,7 +263,7 @@ export type PenpotGradient = {
  * Represents image data in Penpot.
  * This includes properties for defining the image's dimensions, metadata, and aspect ratio handling.
  */
-export type PenpotImageData = {
+export type ImageMixin = {
   /**
    * The optional name of the image.
    */
@@ -287,11 +291,12 @@ export type PenpotImageData = {
   keepApectRatio?: boolean;
 };
 
+// It makes more sense to call it on plural (fills), because is possible to have multiple
 /**
  * Represents fill properties in Penpot.
  * This interface includes properties for defining solid color fills, gradient fills, and image fills.
  */
-export interface PenpotFill {
+export interface FillsMixin {
   /**
    * The optional solid fill color, represented as a string (e.g., '#FF5733').
    */
@@ -304,7 +309,7 @@ export interface PenpotFill {
   /**
    * The optional gradient fill defined by a PenpotGradient object.
    */
-  fillColorGradient?: PenpotGradient;
+  fillColorGradient?: GradientMixin;
   /**
    * The optional reference to an external file for the fill color.
    */
@@ -316,7 +321,7 @@ export interface PenpotFill {
   /**
    * The optional image fill defined by a PenpotImageData object.
    */
-  fillImage?: PenpotImageData;
+  fillImage?: ImageMixin;
 }
 
 /**
@@ -377,7 +382,7 @@ export interface PenpotStroke {
   /**
    * The optional gradient stroke defined by a PenpotGradient object.
    */
-  strokeColorGradient?: PenpotGradient;
+  strokeColorGradient?: GradientMixin;
 }
 
 /**
@@ -417,11 +422,11 @@ export interface PenpotColor {
   /**
    * The optional gradient fill defined by a PenpotGradient object.
    */
-  gradient?: PenpotGradient;
+  gradient?: GradientMixin;
   /**
    * The optional image fill defined by a PenpotImageData object.
    */
-  image?: PenpotImageData;
+  image?: ImageMixin;
 }
 
 /**
@@ -662,13 +667,14 @@ export interface PenpotExport {
  * Represents the type of track in Penpot.
  * This type defines various track types that can be used in layout configurations.
  */
-export type PenpotTrackType = 'flex' | 'fixed' | 'percent' | 'auto';
+export type TrackType = 'flex' | 'fixed' | 'percent' | 'auto';
 
+// TBD: will see if this is a mixin or not
 /**
  * Represents a track configuration in Penpot.
  * This interface includes properties for defining the type and value of a track used in layout configurations.
  */
-export interface PenpotTrack {
+export interface GridLayoutTrack {
   /**
    * The type of the track.
    * This can be one of the following values:
@@ -677,7 +683,7 @@ export interface PenpotTrack {
    * - 'percent': A track type defined by a percentage.
    * - 'auto': An automatic track type.
    */
-  type: PenpotTrackType;
+  type: TrackType;
   /**
    * The value of the track.
    * This can be a number representing the size of the track, or null if not applicable.
@@ -689,7 +695,7 @@ export interface PenpotTrack {
  * PenpotCommonLayout represents a common layout interface in the Penpot application.
  * It includes various properties for alignment, spacing, padding, and sizing, as well as a method to remove the layout.
  */
-export interface PenpotCommonLayout {
+export interface LayoutMixin {
   /**
    * The `alignItems` property specifies the default alignment for items inside the container.
    * It can be one of the following values:
@@ -809,7 +815,7 @@ export interface PenpotCommonLayout {
  * PenpotGridLayout represents a grid layout in the Penpot application, extending the common layout interface.
  * It includes properties and methods to manage rows, columns, and child elements within the grid.
  */
-export interface PenpotGridLayout extends PenpotCommonLayout {
+export interface GridLayoutMixin extends LayoutMixin {
   /**
    * The `dir` property specifies the primary direction of the grid layout.
    * It can be either 'column' or 'row'.
@@ -819,39 +825,39 @@ export interface PenpotGridLayout extends PenpotCommonLayout {
    * The `rows` property represents the collection of rows in the grid.
    * This property is read-only.
    */
-  readonly rows: PenpotTrack[];
+  readonly rows: GridLayoutTrack[];
   /**
    * The `columns` property represents the collection of columns in the grid.
    * This property is read-only.
    */
-  readonly columns: PenpotTrack[];
+  readonly columns: GridLayoutTrack[];
 
   /**
    * Adds a new row to the grid.
    * @param type The type of the row to add.
    * @param value The value associated with the row type (optional).
    */
-  addRow(type: PenpotTrackType, value?: number): void;
+  addRow(type: TrackType, value?: number): void;
   /**
    * Adds a new row to the grid at the specified index.
    * @param index The index at which to add the row.
    * @param type The type of the row to add.
    * @param value The value associated with the row type (optional).
    */
-  addRowAtIndex(index: number, type: PenpotTrackType, value?: number): void;
+  addRowAtIndex(index: number, type: TrackType, value?: number): void;
   /**
    * Adds a new column to the grid.
    * @param type The type of the column to add.
    * @param value The value associated with the column type (optional).
    */
-  addColumn(type: PenpotTrackType, value?: number): void;
+  addColumn(type: TrackType, value?: number): void;
   /**
    * Adds a new column to the grid at the specified index.
    * @param index The index at which to add the column.
    * @param type The type of the column to add.
    * @param value The value associated with the column type.
    */
-  addColumnAtIndex(index: number, type: PenpotTrackType, value: number): void;
+  addColumnAtIndex(index: number, type: TrackType, value: number): void;
   /**
    * Removes a row from the grid at the specified index.
    * @param index The index of the row to remove.
@@ -868,14 +874,14 @@ export interface PenpotGridLayout extends PenpotCommonLayout {
    * @param type The type of the column.
    * @param value The value associated with the column type (optional).
    */
-  setColumn(index: number, type: PenpotTrackType, value?: number): void;
+  setColumn(index: number, type: TrackType, value?: number): void;
   /**
    * Sets the properties of a row at the specified index.
    * @param index The index of the row to set.
    * @param type The type of the row.
    * @param value The value associated with the row type (optional).
    */
-  setRow(index: number, type: PenpotTrackType, value?: number): void;
+  setRow(index: number, type: TrackType, value?: number): void;
 
   /**
    * Appends a child element to the grid at the specified row and column.
@@ -891,7 +897,7 @@ export interface PenpotGridLayout extends PenpotCommonLayout {
  * This interface extends `PenpotCommonLayout` and includes properties for defining the direction,
  * wrapping behavior, and child management of a flex layout.
  */
-export interface PenpotFlexLayout extends PenpotCommonLayout {
+export interface FlexLayoutMixin extends LayoutMixin {
   /**
    * The direction of the flex layout.
    * - 'row': Main axis is horizontal, from left to right.
@@ -1015,10 +1021,11 @@ interface PenpotPathCommand {
   };
 }
 
+// QUESTION: i don't know what's with this one.
 /**
  * Properties for defining the layout of a child element in Penpot.
  */
-export interface PenpotLayoutChildProperties {
+export interface ChildLayoutMixin {
   /**
    * Specifies whether the child element is positioned absolutely.
    * When set to true, the element is taken out of the normal document flow and positioned relative to its nearest positioned ancestor.
@@ -1117,10 +1124,11 @@ export interface PenpotLayoutChildProperties {
   minHeight: number | null;
 }
 
+// I don't know what's with this one either
 /**
  * Properties for defining the layout of a cell in Penpot.
  */
-export interface PenpotLayoutCellProperties {
+export interface CellLayoutProperties {
   /**
    * The row index of the cell.
    * This value is optional and indicates the starting row of the cell.
@@ -1162,7 +1170,7 @@ export interface PenpotLayoutCellProperties {
  * Represents the base properties and methods of a shape in Penpot.
  * This interface provides common properties and methods shared by all shapes.
  */
-export interface PenpotShapeBase extends PenpotPluginData {
+export interface SceneNodeMixin extends PenpotPluginData {
   // NOTE: it will help on long run to split in smaller chunks.
   // TODO: rename to SceneNodeMixin (double-check)
   /**
@@ -1334,7 +1342,7 @@ export interface PenpotShapeBase extends PenpotPluginData {
   /**
    * The fills applied to the shape.
    */
-  fills: PenpotFill[] | 'mixed';
+  fills: FillsMixin[] | 'mixed';
 
   /**
    * The strokes applied to the shape.
@@ -1344,12 +1352,12 @@ export interface PenpotShapeBase extends PenpotPluginData {
   /**
    * Layout properties for children of the shape.
    */
-  readonly layoutChild?: PenpotLayoutChildProperties;
+  readonly layoutChild?: ChildLayoutMixin;
 
   /**
    * Layout properties for cells in a grid layout.
    */
-  readonly layoutCell?: PenpotLayoutChildProperties;
+  readonly layoutCell?: ChildLayoutMixin;
 
   /*
    * Returns true if the current shape is inside a component instance
@@ -1439,7 +1447,7 @@ export interface PenpotShapeBase extends PenpotPluginData {
  * Represents a frame in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties and methods specific to frames.
  */
-export interface FrameNode extends PenpotShapeBase {
+export interface FrameNode extends SceneNodeMixin {
   /**
    * The type of the shape, which is always 'frame' for frames.
    */
@@ -1447,12 +1455,12 @@ export interface FrameNode extends PenpotShapeBase {
   /**
    * The grid layout configuration of the frame, if applicable.
    */
-  readonly grid?: PenpotGridLayout;
+  readonly grid?: GridLayoutMixin;
 
   /**
    * The flex layout configuration of the frame, if applicable.
    */
-  readonly flex?: PenpotFlexLayout;
+  readonly flex?: FlexLayoutMixin;
 
   /**
    * The guides associated with the frame.
@@ -1471,7 +1479,7 @@ export interface FrameNode extends PenpotShapeBase {
   /**
    * The fills applied to the shape.
    */
-  fills: PenpotFill[];
+  fills: FillsMixin[];
 
   // Container Properties
   /**
@@ -1495,19 +1503,19 @@ export interface FrameNode extends PenpotShapeBase {
    * Adds a flex layout configuration to the frame.
    * Returns the flex layout configuration added to the frame.
    */
-  addFlexLayout(): PenpotFlexLayout;
+  addFlexLayout(): FlexLayoutMixin;
   /**
    * Adds a grid layout configuration to the frame.
    * Returns the grid layout configuration added to the frame.
    */
-  addGridLayout(): PenpotGridLayout;
+  addGridLayout(): GridLayoutMixin;
 }
 
 /**
  * Represents a group of shapes in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties and methods specific to groups.
  */
-export interface GroupNode extends PenpotShapeBase {
+export interface GroupNode extends SceneNodeMixin {
   /**
    * The type of the shape, which is always 'group' for groups.
    */
@@ -1560,7 +1568,7 @@ export type PenpotBoolType =
  * Represents a boolean operation shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties and methods specific to boolean operations.
  */
-export interface BooleanNode extends PenpotShapeBase {
+export interface BooleanNode extends SceneNodeMixin {
   /**
    * The type of the shape, which is always 'bool' for boolean operation shapes.
    */
@@ -1579,7 +1587,7 @@ export interface BooleanNode extends PenpotShapeBase {
   /**
    * The fills applied to the shape.
    */
-  fills: PenpotFill[];
+  fills: FillsMixin[];
 
   // Container Properties
   /**
@@ -1603,7 +1611,7 @@ export interface BooleanNode extends PenpotShapeBase {
  * Represents a rectangle shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties specific to rectangles.
  */
-export interface RectangleNode extends PenpotShapeBase {
+export interface RectangleNode extends SceneNodeMixin {
   /**
    * The type of the shape, which is always 'rect' for rectangle shapes.
    */
@@ -1612,14 +1620,14 @@ export interface RectangleNode extends PenpotShapeBase {
   /**
    * The fills applied to the shape.
    */
-  fills: PenpotFill[];
+  fills: FillsMixin[];
 }
 
 /**
  * Represents a path shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties and methods specific to paths.
  */
-export interface VectorNode extends PenpotShapeBase {
+export interface VectorNode extends SceneNodeMixin {
   /**
    * The type of the shape, which is always 'path' for path shapes.
    */
@@ -1637,7 +1645,7 @@ export interface VectorNode extends PenpotShapeBase {
   /**
    * The fills applied to the shape.
    */
-  fills: PenpotFill[];
+  fills: FillsMixin[];
 }
 
 /**
@@ -1719,7 +1727,7 @@ export interface PenpotTextRange {
   /**
    * The fill styles applied to the text range.
    */
-  fills: PenpotFill[] | 'mixed';
+  fills: FillsMixin[] | 'mixed';
 
   /**
    * The horizontal alignment of the text range. It can be a specific alignment or 'mixed' if multiple alignments are used.
@@ -1743,7 +1751,7 @@ export interface PenpotTextRange {
  * PenpotText represents a text element in the Penpot application, extending the base shape interface.
  * It includes various properties to define the text content and its styling attributes.
  */
-export interface TextNode extends PenpotShapeBase {
+export interface TextNode extends SceneNodeMixin {
   /**
    * The type of the shape, which is always 'text' for text shapes.
    */
@@ -1847,20 +1855,20 @@ export interface TextNode extends PenpotShapeBase {
  * Represents an ellipse shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties specific to ellipses.
  */
-export interface EllipseNode extends PenpotShapeBase {
+export interface EllipseNode extends SceneNodeMixin {
   type: 'circle';
 
   /**
    * The fills applied to the shape.
    */
-  fills: PenpotFill[];
+  fills: FillsMixin[];
 }
 
 /**
  * Represents an SVG raw shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties specific to raw SVG shapes.
  */
-export interface SvgRawNode extends PenpotShapeBase {
+export interface SvgRawNode extends SceneNodeMixin {
   type: 'svg-raw';
 }
 
@@ -1868,13 +1876,13 @@ export interface SvgRawNode extends PenpotShapeBase {
  * Represents an image shape in Penpot.
  * This interface extends `PenpotShapeBase` and includes properties specific to image shapes.
  */
-export interface ImageNode extends PenpotShapeBase {
+export interface ImageNode extends SceneNodeMixin {
   type: 'image';
 
   /**
    * The fills applied to the shape.
    */
-  fills: PenpotFill[];
+  fills: FillsMixin[];
 }
 
 /**
@@ -2009,12 +2017,12 @@ export interface PenpotLibraryColor extends PenpotLibraryElement {
   /**
    * The gradient value of the library color, if it's a gradient.
    */
-  gradient?: PenpotGradient;
+  gradient?: GradientMixin;
 
   /**
    * The image data of the library color, if it's an image fill.
    */
-  image?: PenpotImageData;
+  image?: ImageMixin;
 
   /**
    * Converts the library color into a fill object.
@@ -2024,7 +2032,7 @@ export interface PenpotLibraryColor extends PenpotLibraryElement {
    * const fill = libraryColor.asFill();
    * ```
    */
-  asFill(): PenpotFill;
+  asFill(): FillsMixin;
   /**
    * Converts the library color into a stroke object.
    * Returns a `PenpotStroke` object representing the color as a stroke.
@@ -2613,7 +2621,7 @@ export interface PenpotContext {
    * const imageData = await context.uploadMediaUrl('example', 'https://example.com/image.jpg');
    * ```
    */
-  uploadMediaUrl(name: string, url: string): Promise<PenpotImageData>;
+  uploadMediaUrl(name: string, url: string): Promise<ImageMixin>;
 
   /**
    * Uploads media to penpot and retrieves the image data. Requires `content:write` permission.
@@ -2625,7 +2633,7 @@ export interface PenpotContext {
     name: string,
     data: Uint8Array,
     mimeType: string
-  ): Promise<PenpotImageData>;
+  ): Promise<ImageMixin>;
 
   /**
    * Groups the specified shapes. Requires `content:write` permission.


### PR DESCRIPTION
⚠️ This pull request contains breaking changes due to name changes of the properties. For example: `PageNode.pages` became `PageNode.children` for consistency.

⚠️ This is also incomplete because I rushed, seeing that you're pushing new changes pretty often. I want to avoid falling too far behind or spending time in vain.

### Why the following proposal
1. The current names are too long due to the repetition of the word "Penpot" everywhere.
1. As a developer, you might be aware of the importance of having a naming convention when you're working in a team. Such a convention will offer predictability in the long run and will help avoid unnecessary breaking changes due to lack of clarity.
2. This proposal will also increase the chance for people to migrate to Penpot, as it is similar to Figma's API. There will be no need to learn a new language to create Penpot plugins.

### Naming convention proposal
1. Use {Name + "Node"} for new node entities. e.g. ComponentNode or InstanceNode.
2. Use {Name + "Node" + "Mixin"} for node-related properties mixins. E.g. FrameNodeMixin or TextNodeMixin
3. Use {Name + "Mixin"} for properties mixins. E.g. GridLayoutMixin or FlexLayoutMixin.
4. Additional, if there is a minimum required mixin, then it can be called {"Minimal" + MixinName}
5. Constant values to be written with uppercase. E.g.: type: "LINEAR" | "RADIAL".

Right now it's a bit messy, especially with properties. For example, PenpotLayoutChildProperties versus PenpotCommonLayout.

The context is also important: we're already inside a Penpot file, so there is no need to repeat "Penpot" everywhere. Repeating "Penpot" makes everything longer without adding any value.