### PR TITLE
fix: horizontal scroll height on plugins modal

### DIFF
--- a/libs/plugins-styles/src/lib/core/generic.css
+++ b/libs/plugins-styles/src/lib/core/generic.css
@@ -76,6 +76,7 @@ ul {
 /* ===== Scrollbar CSS ===== */
 ::-webkit-scrollbar {
   width: 5px;
+  height: 5px;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
Horizontal scroll on penpot modal does not look similar to vertical scroll.