### PR TITLE
Update plugins

### DIFF
--- a/apps/poc-state-plugin/src/app/app.component.ts
+++ b/apps/poc-state-plugin/src/app/app.component.ts
@@ -90,6 +90,28 @@ import type { Shape } from '@penpot/plugin-types';
         >
           Rotate
         </button>
+        <button
+          type="button"
+          data-appearance="secondary"
+          (click)="createMargins()"
+        >
+          Add Margins
+        </button>
+
+        <button
+          type="button"
+          data-appearance="secondary"
+          (click)="addComment()"
+        >
+          Add comment
+        </button>
+        <button
+          type="button"
+          data-appearance="secondary"
+          (click)="exportFile()"
+        >
+          Export File
+        </button>
 
         <input type="file" class="file-upload" (change)="uploadImage($event)" />
       </div>
@@ -146,6 +168,8 @@ export class AppComponent {
         this.theme.set(event.data.content);
       } else if (event.data.type === 'update-counter') {
         this.counter.set(event.data.content.counter);
+      } else if (event.data.type === 'start-download') {
+        this.#startDownload(event.data.content);
       }
     });
 
@@ -218,6 +242,18 @@ export class AppComponent {
     this.#sendMessage({ content: 'rotate-selection' });
   }
 
+  createMargins() {
+    this.#sendMessage({ content: 'create-margins' });
+  }
+
+  addComment() {
+    this.#sendMessage({ content: 'add-comment' });
+  }
+
+  exportFile() {
+    this.#sendMessage({ content: 'export-file' });
+  }
+
   async uploadImage(event: Event) {
     const input = event.target as HTMLInputElement;
     if (input?.files?.length) {
@@ -252,5 +288,23 @@ export class AppComponent {
     } else {
       this.form.get('name')?.setValue('');
     }
+  }
+
+  #startDownload(data: Uint8Array) {
+    const blob = new Blob([data], { type: 'application/octet-stream' });
+
+    // We need to start a download with this URL
+    const downloadURL = URL.createObjectURL(blob);
+
+    // Download
+    var a = document.createElement('a');
+    document.body.appendChild(a);
+    a.href = downloadURL;
+    a.download = 'Export.penpot';
+    a.click();
+
+    // Remove temporary
+    URL.revokeObjectURL(a.href);
+    a.remove();
   }
 }

--- a/apps/poc-state-plugin/src/assets/manifest.json
+++ b/apps/poc-state-plugin/src/assets/manifest.json
@@ -3,10 +3,10 @@
   "description": "Sandbox plugin for plugins development",
   "code": "/assets/plugin.js",
   "permissions": [
-    "content:read",
     "content:write",
-    "library:read",
     "library:write",
-    "user:read"
+    "comment:write",
+    "user:read",
+    "allow:downloads"
   ]
 }

--- a/docs/create-angular-plugin.md
+++ b/docs/create-angular-plugin.md
@@ -27,11 +27,11 @@ Next, create a `manifest.json` file inside the `/src/assets` directory. This fil
   "code": "/assets/plugin.js",
   "icon": "/assets/icon.png",
   "permissions": [
-    "content:read",
     "content:write",
-    "library:read",
     "library:write",
-    "user:read"
+    "user:read",
+    "comment:read",
+    "allow:downloads"
   ]
 }
 ```

--- a/docs/create-plugin.md
+++ b/docs/create-plugin.md
@@ -31,11 +31,11 @@ Next, create a `manifest.json` file inside the `/public` directory. This file is
   "code": "/plugin.js",
   "icon": "/icon.png",
   "permissions": [
-    "content:read",
     "content:write",
-    "library:read",
     "library:write",
-    "user:read"
+    "user:read",
+    "comment:read",
+    "allow:downloads"
   ]
 }
 ```

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -497,6 +497,7 @@ export interface Comment {
 
   /**
    * Remove the current comment from its comment thread. Only the owner can remove their comments.
+   * Requires the `comment:write` permission.
    */
   remove(): void;
 }
@@ -535,18 +536,21 @@ export interface CommentThread {
 
   /**
    * List of `comments` ordered by creation date.
+   * Requires the `comment:read` o `comment:write` permission.
    */
   findComments(): Promise<Comment[]>;
 
   /**
    * Creates a new comment after the last one in the thread. The current user will
    * be used as the creation user.
+   * Requires the `comment:write` permission.
    */
   reply(content: string): Promise<Comment>;
 
   /**
    * Removes the current comment thread. Only the user that created the thread can
    * remove it.
+   * Requires the `comment:write` permission.
    */
   remove(): void;
 }
@@ -2840,11 +2844,13 @@ export interface Page extends PluginData {
    * Creates a new comment thread in the `position`. Optionaly adds
    * it into the `board`.
    * Returns the thread created.
+   * Requires the `comment:write` permission.
    */
   addCommentThread(content: string, position: Point): Promise<CommentThread>;
 
   /**
    * Removes the comment thread.
+   * Requires the `comment:read` or `comment:write` permission.
    */
   removeCommentThread(commentThread: CommentThread): Promise<void>;
 
@@ -2854,8 +2860,9 @@ export interface Page extends PluginData {
    *                user has engaged.
    * - `showResolved`: by default resolved comments will be hidden. If `true`
    *                   the resolved will be returned.
+   * Requires the `comment:read` or `comment:write` permission.
    */
-  findCommentThreads(criteria: {
+  findCommentThreads(criteria?: {
     onlyYours: boolean;
     showResolved: boolean;
   }): Promise<CommentThread[]>;

--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -2850,7 +2850,7 @@ export interface Page extends PluginData {
 
   /**
    * Removes the comment thread.
-   * Requires the `comment:read` or `comment:write` permission.
+   * Requires the `comment:write` permission.
    */
   removeCommentThread(commentThread: CommentThread): Promise<void>;
 

--- a/libs/plugins-runtime/src/lib/api/openUI.api.ts
+++ b/libs/plugins-runtime/src/lib/api/openUI.api.ts
@@ -8,8 +8,9 @@ export const openUIApi = z
     z.string(),
     z.string(),
     z.enum(['dark', 'light']),
-    openUISchema.optional()
+    openUISchema.optional(),
+    z.boolean().optional()
   )
-  .implement((title, url, theme, options) => {
-    return createModal(title, url, theme, options);
+  .implement((title, url, theme, options, allowDownloads) => {
+    return createModal(title, url, theme, options, allowDownloads);
   });

--- a/libs/plugins-runtime/src/lib/api/plugin-api.spec.ts
+++ b/libs/plugins-runtime/src/lib/api/plugin-api.spec.ts
@@ -18,6 +18,9 @@ describe('Plugin api', () => {
           'library:read',
           'library:write',
           'user:read',
+          'comment:read',
+          'comment:write',
+          'allow:downloads',
         ],
       },
       openModal: vi.fn(),
@@ -107,7 +110,7 @@ describe('Plugin api', () => {
         name: 'test',
         id: '123',
         revn: 0,
-    } as File;
+      } as File;
 
       pluginManager.context.getFile.mockImplementation(() => exampleFile);
 

--- a/libs/plugins-runtime/src/lib/create-modal.ts
+++ b/libs/plugins-runtime/src/lib/create-modal.ts
@@ -6,7 +6,8 @@ export function createModal(
   name: string,
   url: string,
   theme: Theme,
-  options?: OpenUIOptions
+  options?: OpenUIOptions,
+  allowDownloads?: boolean
 ) {
   const modal = document.createElement('plugin-modal') as PluginModalElement;
 
@@ -43,6 +44,10 @@ export function createModal(
   modal.setAttribute('iframe-src', url);
   modal.setAttribute('width', String(width));
   modal.setAttribute('height', String(height));
+
+  if (allowDownloads) {
+    modal.setAttribute('allow-downloads', 'true');
+  }
 
   document.body.appendChild(modal);
 

--- a/libs/plugins-runtime/src/lib/create-plugin.spec.ts
+++ b/libs/plugins-runtime/src/lib/create-plugin.spec.ts
@@ -32,6 +32,9 @@ describe('createPlugin', () => {
         'library:read',
         'library:write',
         'user:read',
+        'comment:read',
+        'comment:write',
+        'allow:downloads',
       ],
     };
 

--- a/libs/plugins-runtime/src/lib/create-sandbox.ts
+++ b/libs/plugins-runtime/src/lib/create-sandbox.ts
@@ -55,6 +55,7 @@ export function createSandbox(
     penpot: proxyApi,
     fetch: ses.harden(safeFetch),
     console: ses.harden(window.console),
+    Date: ses.harden(Date),
     Math: ses.harden(Math),
     setTimeout: ses.harden(
       (...[handler, timeout]: Parameters<typeof setTimeout>) => {

--- a/libs/plugins-runtime/src/lib/load-plugin.spec.ts
+++ b/libs/plugins-runtime/src/lib/load-plugin.spec.ts
@@ -43,6 +43,9 @@ describe('plugin-loader', () => {
         'library:read',
         'library:write',
         'user:read',
+        'comment:read',
+        'comment:write',
+        'allow:downloads',
       ],
     };
 

--- a/libs/plugins-runtime/src/lib/modal/plugin-modal.ts
+++ b/libs/plugins-runtime/src/lib/modal/plugin-modal.ts
@@ -43,6 +43,7 @@ export class PluginModalElement extends HTMLElement {
     const iframeSrc = this.getAttribute('iframe-src');
     const width = Number(this.getAttribute('width') || '300');
     const height = Number(this.getAttribute('height') || '400');
+    const allowDownloads = this.getAttribute('allow-downloads') || false;
 
     if (!title || !iframeSrc) {
       throw new Error('title and iframe-src attributes are required');
@@ -99,6 +100,10 @@ export class PluginModalElement extends HTMLElement {
       'allow-popups-to-escape-sandbox',
       'allow-storage-access-by-user-activation'
     );
+
+    if (allowDownloads) {
+      iframe.sandbox.add('allow-downloads');
+    }
 
     iframe.addEventListener('load', () => {
       this.shadowRoot?.dispatchEvent(

--- a/libs/plugins-runtime/src/lib/models/manifest.schema.ts
+++ b/libs/plugins-runtime/src/lib/models/manifest.schema.ts
@@ -14,6 +14,9 @@ export const manifestSchema = z.object({
       'library:read',
       'library:write',
       'user:read',
+      'comment:read',
+      'comment:write',
+      'allow:downloads',
     ])
   ),
 });

--- a/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
+++ b/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
@@ -40,6 +40,9 @@ describe('createPluginManager', () => {
         'library:read',
         'library:write',
         'user:read',
+        'comment:read',
+        'comment:write',
+        'allow:downloads',
       ],
     };
 

--- a/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
+++ b/libs/plugins-runtime/src/lib/plugin-manager.spec.ts
@@ -114,7 +114,8 @@ describe('createPluginManager', () => {
       'Test Modal',
       'https://example.com/plugin',
       'light',
-      { width: 400, height: 300 }
+      { width: 400, height: 300 },
+      true
     );
     expect(mockModal.setTheme).toHaveBeenCalledWith('light');
     expect(mockModal.addEventListener).toHaveBeenCalledWith(

--- a/libs/plugins-runtime/src/lib/plugin-manager.ts
+++ b/libs/plugins-runtime/src/lib/plugin-manager.ts
@@ -21,6 +21,10 @@ export async function createPluginManager(
   let uiMessagesCallbacks: ((message: unknown) => void)[] = [];
   const timeouts = new Set<ReturnType<typeof setTimeout>>();
 
+  const allowDownloads = !!manifest.permissions.find(
+    (s) => s === 'allow:downloads'
+  );
+
   const themeChangeId = context.addListener('themechange', (theme: Theme) => {
     modal?.setTheme(theme);
   });
@@ -83,7 +87,7 @@ export async function createPluginManager(
       return;
     }
 
-    modal = openUIApi(name, modalUrl, theme, options);
+    modal = openUIApi(name, modalUrl, theme, options, allowDownloads);
 
     modal.setTheme(theme);
 


### PR DESCRIPTION
- Adds new permissions: `comment:write`, `comment:read` and `allow:download`
- Allows downloads from the iframe when the permission is added to the manifest
- Adds `Date` to the list of permitted global objects
- Updates types with the new permissions
- Update the `poc-state-plugin` adding an example to create ruler guides, comments and download an export