### PR TITLE
fix: duplicated css

### DIFF
--- a/libs/plugins-styles/src/lib/core/fonts.css
+++ b/libs/plugins-styles/src/lib/core/fonts.css
@@ -13,13 +13,6 @@
   --font-size-l: 16px;
 }
 
-html,
-body {
-  font-family: 'Work Sans', sans-serif;
-  font-optical-sizing: auto;
-  font-style: normal;
-}
-
 code {
   font-family: 'Work Sans', sans-serif;
 }


### PR DESCRIPTION
These styles are not removed during the build process. The duplicated CSS can be seen [here in generic.css file](https://github.com/penpot/penpot-plugins/blob/dfbc9a99ae6403f5b5e937da329c92aee249a0fa/libs/plugins-styles/src/lib/core/generic.css#L1-L5).

Since `generic.css` is the first imported file and has more rules, I leave it untouched.

Moreover, let's consider not using Google Fonts because of their tracking and unnecessary requests to 3rd party.