### PR TITLE
fix(plugins-styles): migrate to fonts css api v2

### DIFF
--- a/libs/plugins-styles/src/lib/core/fonts.css
+++ b/libs/plugins-styles/src/lib/core/fonts.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Work+Sans:wght@400+500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500&display=swap');
 
 :root {
   /* Font weight */


### PR DESCRIPTION
Google Fonts CSS API v1 fallbacks to `font-weight: 400`, when `font-weight: 500` is expected to be rendered in plugin.

This fix provides new Google Fonts CSS API v2 URL for **Work Sans** font.

More info: https://developers.google.com/fonts/docs/css2#individual_styles_such_as_weight