### PR TITLE
fix: fonts gdpr & switch provider

### DIFF
--- a/libs/plugins-styles/src/lib/core/fonts.css
+++ b/libs/plugins-styles/src/lib/core/fonts.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@400;500&display=swap');
+@import url('https://fonts.bunny.net/css?family=work-sans:400,500&display=swap');
 
 :root {
   /* Font weight */


### PR DESCRIPTION
According to many resources, Google Fonts are not (likely) GDPR-compliant, and track users. Moreover, users should give a consent.

I propose using EU-based alternative Bunny Fonts, as mentioned [on this page](https://european-alternatives.eu/alternative-to/google-fonts). They are a direct drop-in replacement, so even the old Google Fonts' URL (with domain changed to Bunny) will work.