### PR TITLE
feat(plugins-runtime): allow openPage()  to toggle opening a new window

### DIFF
--- a/libs/plugin-types/index.d.ts
+++ b/libs/plugin-types/index.d.ts
@@ -1231,13 +1231,14 @@ export interface Context {
   /**
    * Changes the current open page to given page. Requires `content:read` permission.
    * @param page the page to open
+   * @param newWindow if true opens the page in a new window
    *
    * @example
    * ```js
    * context.openPage(page);
    * ```
    */
-  openPage(page: Page): void;
+  openPage(page: Page, newWindow?: boolean): void;
 
   /**
    * Aligning will move all the selected layers to a position relative to one

--- a/libs/plugins-runtime/src/lib/api/index.ts
+++ b/libs/plugins-runtime/src/lib/api/index.ts
@@ -317,9 +317,9 @@ export function createApi(
       return plugin.context.createPage();
     },
 
-    openPage(page: Page): void {
+    openPage(page: Page, newWindow?: boolean): void {
       checkPermission('content:read');
-      plugin.context.openPage(page);
+      plugin.context.openPage(page, newWindow ?? true);
     },
 
     alignHorizontal(


### PR DESCRIPTION
### Summary

This PR adds the extension to the `:openPage` command in `page-proxy` and context with an additional parameter [submitted here](https://github.com/penpot/penpot/pull/7753). The parameter allows toggling the current default behaviour of always opening new `Pages` in separate browser tabs/windows.

I believe this is necessary because it's AFAICT otherwise impossible for plugins to navigate to shapes outside the current page. As it is right now, the plugin is unloaded in the new browser tab, making any action subsequent to `openPage` impossible.

### Open questions:

1. In order not to break expectations for API users, I've handled `undefined` in the second argument to have the previous behaviour. Maybe there's another preferred way of handling defaults.
2. I have also done this in the frontend's code, which is redundant, but I'm not sure what the release process is, and whether or not it is possible for someone to mix versions
3. I see that the `page-proxy` has [an `:openPage` slot as well](https://github.com/penpot/penpot/blob/665587d492e91d99235fbb4d1dfb429ef52b3c22/frontend/src/app/plugins/page.cljs#L265), but this is not exposed in the API. Should we add that? And if we do, wouldn't it make more sense to call it `:open`, since it's already inside `Page`?